### PR TITLE
[Step4] 인터셉터와 캐싱 작업을 추가한다. 

### DIFF
--- a/src/main/java/project/server/spring/app/core/controller/base/BaseController.java
+++ b/src/main/java/project/server/spring/app/core/controller/base/BaseController.java
@@ -1,12 +1,9 @@
 package project.server.spring.app.core.controller.base;
 
-import static project.server.spring.app.core.global.error.ErrorMessage.*;
-
 import java.util.HashMap;
 import java.util.Map;
 
 import project.server.spring.app.core.dto.UserInfoDto;
-import project.server.spring.app.core.global.exception.AuthenticationException;
 import project.server.spring.app.core.service.user.UserService;
 import project.server.spring.framework.annotation.Controller;
 import project.server.spring.framework.annotation.RequestMapping;
@@ -38,9 +35,6 @@ public class BaseController {
 	@RequestMapping(value = "/profile", method = HttpMethod.GET)
 	public ModelAndView profile(HttpServletRequest request, HttpServletResponse response) {
 		HttpSession session = request.getSession();
-		if (session == null) {
-			throw new AuthenticationException(AUTHENTICATION_FAILED.getMessage());
-		}
 		Long userId = (Long)session.getAttribute(USER_ID);
 		ModelAndView modelAndView = new ModelAndView("my-info");
 		UserInfoDto userInfo = userService.getUserInfo(userId);

--- a/src/main/java/project/server/spring/app/core/global/auth/AuthConfig.java
+++ b/src/main/java/project/server/spring/app/core/global/auth/AuthConfig.java
@@ -1,0 +1,21 @@
+package project.server.spring.app.core.global.auth;
+
+import project.server.spring.framework.annotation.Configuration;
+import project.server.spring.framework.mvc.InterceptorRegistry;
+import project.server.spring.framework.mvc.WebMvcConfigurer;
+
+@Configuration
+public class AuthConfig implements WebMvcConfigurer {
+	private final AuthenticationInterceptor authenticationInterceptor;
+
+	public AuthConfig(AuthenticationInterceptor authenticationInterceptor) {
+		this.authenticationInterceptor = authenticationInterceptor;
+	}
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(authenticationInterceptor)
+			.addUris("/profile")
+			.order(1);
+	}
+}

--- a/src/main/java/project/server/spring/app/core/global/auth/AuthenticationInterceptor.java
+++ b/src/main/java/project/server/spring/app/core/global/auth/AuthenticationInterceptor.java
@@ -1,0 +1,26 @@
+package project.server.spring.app.core.global.auth;
+
+import static project.server.spring.app.core.global.error.ErrorMessage.*;
+
+import lombok.extern.slf4j.Slf4j;
+import project.server.spring.app.core.global.exception.AuthenticationException;
+import project.server.spring.framework.http.HttpSession;
+import project.server.spring.framework.servlet.HttpServletRequest;
+import project.server.spring.framework.servlet.HttpServletResponse;
+import project.server.spring.framework.servlet.handler.HandlerInterceptor;
+
+@Slf4j
+public class AuthenticationInterceptor extends HandlerInterceptor {
+	private static final String USER_ID = "user_id";
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws
+		Exception {
+		log.info("authentication is required : request {}", request.getRequestURI());
+		HttpSession session = request.getSession();
+		if (session == null || session.getAttribute(USER_ID) == null) {
+			throw new AuthenticationException(AUTHENTICATION_FAILED.getMessage());
+		}
+		return true;
+	}
+}

--- a/src/main/java/project/server/spring/framework/RequestHandler.java
+++ b/src/main/java/project/server/spring/framework/RequestHandler.java
@@ -8,19 +8,19 @@ import java.net.Socket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import project.server.spring.framework.context.ApplicationContext;
 import project.server.spring.framework.http.SyncHttpRequest;
 import project.server.spring.framework.http.SyncHttpResponse;
 import project.server.spring.framework.servlet.DispatcherServlet;
 
 public final class RequestHandler extends Thread {
 	private static final Logger log = LoggerFactory.getLogger(RequestHandler.class);
-	private final DispatcherServlet dispatcherServlet;
+	private final DispatcherServlet dispatcherServlet = ApplicationContext.getBean(DispatcherServlet.class);
 
 	private Socket connection;
 
 	public RequestHandler(Socket connectionSocket) {
 		this.connection = connectionSocket;
-		this.dispatcherServlet = DispatcherServlet.getInstance();
 	}
 
 	@Override

--- a/src/main/java/project/server/spring/framework/cache/DefaultPageMap.java
+++ b/src/main/java/project/server/spring/framework/cache/DefaultPageMap.java
@@ -1,0 +1,51 @@
+package project.server.spring.framework.cache;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+public class DefaultPageMap {
+	private static final String EXTENSION = ".html";
+	private static final String ERROR_PAGE_PATH = "/assets/error/";
+	private final Map<Integer, String> pageMap = new HashMap<>();
+
+	private static final int CLIENT_ERROR_DEFAULT_PAGE = 400;
+	private static final int SERVER_ERROR_DEFAULT_PAGE = 500;
+
+	public DefaultPageMap() {
+		loadDefaultPages();
+	}
+
+	private void loadDefaultPages() {
+		loadPage(CLIENT_ERROR_DEFAULT_PAGE);
+		loadPage(SERVER_ERROR_DEFAULT_PAGE);
+	}
+
+	private void loadPage(int status) {
+		try {
+			String filePath = ERROR_PAGE_PATH + status + EXTENSION;
+			InputStream inputStream = DefaultPageMap.class.getResourceAsStream(filePath);
+			if (inputStream == null) {
+				throw new IOException();
+			}
+			byte[] bytes = inputStream.readAllBytes();
+			String page = new String(bytes);
+			pageMap.put(status, page);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public String getPage(int status) {
+		if (pageMap.get(status) != null) {
+			return pageMap.get(status);
+		}
+		return getDefaultPage(status);
+	}
+
+	private String getDefaultPage(int status) {
+		int defaultErrorPageCode = (status / 100) * 100;
+		return pageMap.get(defaultErrorPageCode);
+	}
+}

--- a/src/main/java/project/server/spring/framework/configuration/ConfigLoader.java
+++ b/src/main/java/project/server/spring/framework/configuration/ConfigLoader.java
@@ -18,8 +18,8 @@ public class ConfigLoader {
 	}
 
 	private ConfigMap loadConfigMap(String resourcePath) throws IOException {
-		InputStream inputStream = ConfigLoader.class.
-			getResourceAsStream(resourcePath);
+		InputStream inputStream = ConfigLoader.class
+			.getResourceAsStream(resourcePath);
 		if (inputStream == null) {
 			throw new IllegalArgumentException("resource not found " + resourcePath);
 		}
@@ -27,5 +27,4 @@ public class ConfigLoader {
 		objectMapper.setPropertyNamingStrategy(new PropertyNamingStrategies.KebabCaseStrategy());
 		return objectMapper.readValue(inputStream, ConfigMap.class);
 	}
-
 }

--- a/src/main/java/project/server/spring/framework/context/MappingRegistry.java
+++ b/src/main/java/project/server/spring/framework/context/MappingRegistry.java
@@ -1,0 +1,54 @@
+package project.server.spring.framework.context;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import project.server.spring.framework.annotation.Controller;
+import project.server.spring.framework.annotation.RequestMapping;
+import project.server.spring.framework.servlet.handler.HandlerMethod;
+import project.server.spring.framework.servlet.mvc.RequestMappingInfo;
+
+public class MappingRegistry {
+	private Map<RequestMappingInfo, HandlerMethod> handlerMethods = null;
+
+	public MappingRegistry() {
+	}
+
+	private void findMappingHandlers() {
+		handlerMethods = new HashMap<>();
+		for (Object bean : ApplicationContext.getAllBeans()) {
+			Annotation[] annotations = bean.getClass().getAnnotations();
+			for (Annotation annotation : annotations) {
+				if (annotation.annotationType().equals(Controller.class)) {
+					findMappingMethods(bean);
+				}
+			}
+		}
+	}
+
+	private void findMappingMethods(Object handler) {
+		for (Method method : handler.getClass().getDeclaredMethods()) {
+			if (method.isAnnotationPresent(RequestMapping.class)) {
+				RequestMapping requestMapping = method.getAnnotation(RequestMapping.class);
+				if (requestMapping.value().length == 0 || requestMapping.method().length == 0) {
+					continue;
+				}
+				RequestMappingInfo requestMappingInfo = new RequestMappingInfo(requestMapping.method()[0],
+					requestMapping.value()[0]);
+				if (handlerMethods.get(requestMappingInfo) != null) {
+					throw new IllegalStateException("handler method duplicated");
+				}
+				handlerMethods.put(requestMappingInfo, new HandlerMethod(handler, method));
+			}
+		}
+	}
+
+	public HandlerMethod getHandlerMethod(RequestMappingInfo info) {
+		if (handlerMethods == null) {
+			findMappingHandlers();
+		}
+		return handlerMethods.get(info);
+	}
+}

--- a/src/main/java/project/server/spring/framework/context/WebMvcConfigurerComposite.java
+++ b/src/main/java/project/server/spring/framework/context/WebMvcConfigurerComposite.java
@@ -1,0 +1,18 @@
+package project.server.spring.framework.context;
+
+import java.util.List;
+
+import project.server.spring.framework.mvc.InterceptorRegistry;
+import project.server.spring.framework.mvc.WebMvcConfigurer;
+
+public class WebMvcConfigurerComposite {
+	private final List<WebMvcConfigurer> configurers;
+
+	public WebMvcConfigurerComposite() {
+		configurers = ApplicationContext.getBeans(WebMvcConfigurer.class);
+		InterceptorRegistry interceptorRegistry = ApplicationContext.getBean(InterceptorRegistry.class);
+		for (WebMvcConfigurer configurer : configurers) {
+			configurer.addInterceptors(interceptorRegistry);
+		}
+	}
+}

--- a/src/main/java/project/server/spring/framework/exception/DataAccessException.java
+++ b/src/main/java/project/server/spring/framework/exception/DataAccessException.java
@@ -1,6 +1,6 @@
 package project.server.spring.framework.exception;
 
-public class DataAccessException extends RuntimeException {
+public class DataAccessException extends NestedRuntimeException {
 	public DataAccessException(String message) {
 		super(message);
 	}

--- a/src/main/java/project/server/spring/framework/exception/GlobalExceptionHandler.java
+++ b/src/main/java/project/server/spring/framework/exception/GlobalExceptionHandler.java
@@ -1,0 +1,28 @@
+package project.server.spring.framework.exception;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import project.server.spring.framework.cache.DefaultPageMap;
+import project.server.spring.framework.http.HttpStatus;
+import project.server.spring.framework.http.error.ErrorResponse;
+import project.server.spring.framework.servlet.HttpServletResponse;
+
+public class GlobalExceptionHandler {
+	private final DefaultPageMap defaultPageMap = new DefaultPageMap();
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	public void resolveException(HttpServletResponse response, Exception exception) throws IOException {
+		if (!(exception instanceof RuntimeException)) {
+			response.setContentType("text/html; charset=UTF-8");
+			String page = defaultPageMap.getPage(HttpStatus.INTERNAL_SERVER_ERROR.getCode());
+			response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.getCode(), page.getBytes());
+			return;
+		}
+		ErrorResponse errorResponse = objectMapper.readValue(exception.toString(), ErrorResponse.class);
+		String page = defaultPageMap.getPage(errorResponse.getCode());
+		response.setContentType("text/html; charset=UTF-8");
+		response.sendError(errorResponse.getCode(), page.getBytes());
+	}
+}

--- a/src/main/java/project/server/spring/framework/exception/NestedRuntimeException.java
+++ b/src/main/java/project/server/spring/framework/exception/NestedRuntimeException.java
@@ -1,0 +1,34 @@
+package project.server.spring.framework.exception;
+
+import project.server.spring.framework.http.HttpStatus;
+
+public class NestedRuntimeException extends RuntimeException {
+	public NestedRuntimeException() {
+	}
+
+	public NestedRuntimeException(String message) {
+		super(message);
+	}
+
+	public NestedRuntimeException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public NestedRuntimeException(Throwable cause) {
+		super(cause);
+	}
+
+	public NestedRuntimeException(String message, Throwable cause, boolean enableSuppression,
+		boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+
+	@Override
+	public String toString() {
+		return String.format(
+			"{\"code\":%d, \"message\":\"%s\"}",
+			HttpStatus.INTERNAL_SERVER_ERROR.getCode(),
+			getMessage()
+		);
+	}
+}

--- a/src/main/java/project/server/spring/framework/exception/NoHandlerFoundException.java
+++ b/src/main/java/project/server/spring/framework/exception/NoHandlerFoundException.java
@@ -1,0 +1,4 @@
+package project.server.spring.framework.exception;
+
+public class NoHandlerFoundException extends NestedRuntimeException {
+}

--- a/src/main/java/project/server/spring/framework/exception/ServletException.java
+++ b/src/main/java/project/server/spring/framework/exception/ServletException.java
@@ -1,0 +1,10 @@
+package project.server.spring.framework.exception;
+
+public class ServletException extends Exception {
+	public ServletException() {
+	}
+
+	public ServletException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/project/server/spring/framework/mvc/InterceptorRegistration.java
+++ b/src/main/java/project/server/spring/framework/mvc/InterceptorRegistration.java
@@ -1,0 +1,46 @@
+package project.server.spring.framework.mvc;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import project.server.spring.framework.servlet.HttpServletRequest;
+import project.server.spring.framework.servlet.handler.HandlerInterceptor;
+
+public class InterceptorRegistration {
+	private final HandlerInterceptor interceptor;
+	private final List<String> uris;
+	private int order = 0;
+
+	public InterceptorRegistration(HandlerInterceptor interceptor) {
+		if (interceptor == null) {
+			throw new IllegalArgumentException("Interceptor is required");
+		}
+		this.interceptor = interceptor;
+		this.uris = new ArrayList<>();
+
+	}
+
+	public InterceptorRegistration addUris(String... uris) {
+		this.uris.addAll(Arrays.asList(uris));
+		return this;
+	}
+
+	public InterceptorRegistration order(int order) {
+		this.order = order;
+		return this;
+	}
+
+	public boolean matches(HttpServletRequest request) {
+		for (String uri : uris) {
+			if (request.getRequestURI().contains(uri)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public HandlerInterceptor getInterceptor() {
+		return interceptor;
+	}
+}

--- a/src/main/java/project/server/spring/framework/mvc/InterceptorRegistry.java
+++ b/src/main/java/project/server/spring/framework/mvc/InterceptorRegistry.java
@@ -1,0 +1,27 @@
+package project.server.spring.framework.mvc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import project.server.spring.framework.annotation.Component;
+import project.server.spring.framework.servlet.handler.HandlerInterceptor;
+
+@Component
+public class InterceptorRegistry {
+
+	List<InterceptorRegistration> registrations;
+
+	public InterceptorRegistry() {
+		this.registrations = new ArrayList<>();
+	}
+
+	public InterceptorRegistration addInterceptor(HandlerInterceptor interceptor) {
+		InterceptorRegistration registration = new InterceptorRegistration(interceptor);
+		registrations.add(registration);
+		return registration;
+	}
+
+	public List<InterceptorRegistration> getInterceptors() {
+		return registrations;
+	}
+}

--- a/src/main/java/project/server/spring/framework/mvc/WebMvcConfigurer.java
+++ b/src/main/java/project/server/spring/framework/mvc/WebMvcConfigurer.java
@@ -1,0 +1,9 @@
+package project.server.spring.framework.mvc;
+
+import project.server.spring.framework.annotation.Component;
+
+@Component
+public interface WebMvcConfigurer {
+	default void addInterceptors(InterceptorRegistry registry) {
+	}
+}

--- a/src/main/java/project/server/spring/framework/servlet/handler/HandlerAdapter.java
+++ b/src/main/java/project/server/spring/framework/servlet/handler/HandlerAdapter.java
@@ -1,0 +1,13 @@
+package project.server.spring.framework.servlet.handler;
+
+import project.server.spring.framework.annotation.Component;
+import project.server.spring.framework.servlet.HttpServletRequest;
+import project.server.spring.framework.servlet.HttpServletResponse;
+import project.server.spring.framework.servlet.ModelAndView;
+
+@Component
+public interface HandlerAdapter {
+	boolean supports(Object handler);
+
+	ModelAndView handle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception;
+}

--- a/src/main/java/project/server/spring/framework/servlet/handler/HandlerExecutionChain.java
+++ b/src/main/java/project/server/spring/framework/servlet/handler/HandlerExecutionChain.java
@@ -1,0 +1,88 @@
+package project.server.spring.framework.servlet.handler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.base.Objects;
+
+import lombok.extern.slf4j.Slf4j;
+import project.server.spring.framework.servlet.HttpServletRequest;
+import project.server.spring.framework.servlet.HttpServletResponse;
+import project.server.spring.framework.servlet.ModelAndView;
+
+@Slf4j
+public class HandlerExecutionChain {
+	private int interceptorIndex = -1;
+	private final Object handler;
+	private final List<HandlerInterceptor> interceptors;
+
+	public HandlerExecutionChain(Object handler) {
+		this.handler = handler;
+		this.interceptors = new ArrayList<>();
+	}
+
+	public boolean applyPreHandle(
+		HttpServletRequest request,
+		HttpServletResponse response
+	) throws Exception {
+		for (int i = 0; i < this.interceptors.size(); i++) {
+			HandlerInterceptor interceptor = this.interceptors.get(i);
+			if (!interceptor.preHandle(request, response, this.handler)) {
+				triggerAfterCompletion(request, response, null);
+				return false;
+			}
+			this.interceptorIndex = i;
+		}
+		return true;
+	}
+
+	public void applyPostHandle(HttpServletRequest request, HttpServletResponse response, ModelAndView modelAndView)
+		throws Exception {
+		for (int i = this.interceptors.size() - 1; i >= 0; i--) {
+			HandlerInterceptor interceptor = this.interceptors.get(i);
+			interceptor.postHandle(request, response, this.handler, modelAndView);
+		}
+	}
+
+	private void triggerAfterCompletion(HttpServletRequest request, HttpServletResponse response, Exception exception) {
+		for (int i = this.interceptorIndex; i >= 0; i--) {
+			HandlerInterceptor interceptor = this.interceptors.get(i);
+			try {
+				interceptor.afterCompletion(request, response, this.handler, exception);
+			} catch (Throwable throwable) {
+				log.error("HandlerInterceptor.afterCompletion threw exception", throwable);
+			}
+		}
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+		if (object == null || getClass() != object.getClass()) {
+			return false;
+		}
+		HandlerExecutionChain that = (HandlerExecutionChain)object;
+		return Objects.equal(handler, that.handler);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(handler);
+	}
+
+	@Override
+	public String toString() {
+		return String.format("%s", handler);
+	}
+
+	public Object getHandler() {
+		return handler;
+	}
+
+	public void addInterceptor(HandlerInterceptor interceptor) {
+		this.interceptors.add(interceptor);
+	}
+
+}

--- a/src/main/java/project/server/spring/framework/servlet/handler/HandlerInterceptor.java
+++ b/src/main/java/project/server/spring/framework/servlet/handler/HandlerInterceptor.java
@@ -1,0 +1,20 @@
+package project.server.spring.framework.servlet.handler;
+
+import project.server.spring.framework.servlet.HttpServletRequest;
+import project.server.spring.framework.servlet.HttpServletResponse;
+import project.server.spring.framework.servlet.ModelAndView;
+
+public abstract class HandlerInterceptor {
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws
+		Exception {
+		return false;
+	}
+
+	public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
+		ModelAndView modelAndView) throws Exception {
+	}
+
+	public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler,
+		Exception ex) throws Exception {
+	}
+}

--- a/src/main/java/project/server/spring/framework/servlet/handler/HandlerMapping.java
+++ b/src/main/java/project/server/spring/framework/servlet/handler/HandlerMapping.java
@@ -1,0 +1,9 @@
+package project.server.spring.framework.servlet.handler;
+
+import project.server.spring.framework.annotation.Component;
+import project.server.spring.framework.servlet.HttpServletRequest;
+
+@Component
+public interface HandlerMapping {
+	HandlerExecutionChain getHandler(HttpServletRequest request) throws Exception;
+}

--- a/src/main/java/project/server/spring/framework/servlet/handler/RequestMappingHandlerAdapter.java
+++ b/src/main/java/project/server/spring/framework/servlet/handler/RequestMappingHandlerAdapter.java
@@ -1,0 +1,24 @@
+package project.server.spring.framework.servlet.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import project.server.spring.framework.annotation.Component;
+import project.server.spring.framework.servlet.HttpServletRequest;
+import project.server.spring.framework.servlet.HttpServletResponse;
+import project.server.spring.framework.servlet.ModelAndView;
+
+@Slf4j
+@Component
+public class RequestMappingHandlerAdapter implements HandlerAdapter {
+	@Override
+	public boolean supports(Object handler) {
+		return handler instanceof HandlerMethod;
+	}
+
+	@Override
+	public ModelAndView handle(HttpServletRequest request, HttpServletResponse response, Object handler) throws
+		Exception {
+		HandlerMethod handlerMethod = (HandlerMethod)handler;
+		return (ModelAndView)handlerMethod.getMethod()
+			.invoke(handlerMethod.getHandler(), request, response);
+	}
+}

--- a/src/main/java/project/server/spring/framework/servlet/handler/RequestMappingHandlerMapping.java
+++ b/src/main/java/project/server/spring/framework/servlet/handler/RequestMappingHandlerMapping.java
@@ -1,0 +1,45 @@
+package project.server.spring.framework.servlet.handler;
+
+import project.server.spring.framework.annotation.Component;
+import project.server.spring.framework.context.ApplicationContext;
+import project.server.spring.framework.context.MappingRegistry;
+import project.server.spring.framework.mvc.InterceptorRegistration;
+import project.server.spring.framework.mvc.InterceptorRegistry;
+import project.server.spring.framework.servlet.HttpServletRequest;
+import project.server.spring.framework.servlet.mvc.RequestMappingInfo;
+
+@Component
+public class RequestMappingHandlerMapping implements HandlerMapping {
+	private final InterceptorRegistry interceptorRegistry;
+	private final MappingRegistry mappingRegistry;
+
+	public RequestMappingHandlerMapping(MappingRegistry mappingRegistry) {
+		this.interceptorRegistry = ApplicationContext.getBean(InterceptorRegistry.class);
+		this.mappingRegistry = mappingRegistry;
+	}
+
+	@Override
+	public HandlerExecutionChain getHandler(HttpServletRequest request) throws Exception {
+		HandlerMethod handlerMethod = getHandlerInternal(request);
+		return getHandlerExecutionChain(handlerMethod, request);
+	}
+
+	private HandlerExecutionChain getHandlerExecutionChain(
+		Object handler,
+		HttpServletRequest request
+	) {
+		HandlerExecutionChain chain = new HandlerExecutionChain(handler);
+		for (InterceptorRegistration interceptorRegistration : interceptorRegistry.getInterceptors()) {
+			if (interceptorRegistration.matches(request)) {
+				chain.addInterceptor(interceptorRegistration.getInterceptor());
+			}
+		}
+		return chain;
+	}
+
+	private HandlerMethod getHandlerInternal(HttpServletRequest request) throws Exception {
+		RequestMappingInfo requestMappingInfo = new RequestMappingInfo(request.getHttpMethod(),
+			request.getRequestURI());
+		return mappingRegistry.getHandlerMethod(requestMappingInfo);
+	}
+}

--- a/src/main/java/project/server/spring/framework/servlet/mvc/RequestMappingInfo.java
+++ b/src/main/java/project/server/spring/framework/servlet/mvc/RequestMappingInfo.java
@@ -1,0 +1,33 @@
+package project.server.spring.framework.servlet.mvc;
+
+import com.google.common.base.Objects;
+
+import project.server.spring.framework.http.HttpMethod;
+
+public class RequestMappingInfo {
+	private final HttpMethod httpMethod;
+	private final String url;
+
+	public RequestMappingInfo(HttpMethod httpMethod, String url) {
+		this.httpMethod = httpMethod;
+		this.url = url;
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+		if (object == null || getClass() != object.getClass()) {
+			return false;
+		}
+		RequestMappingInfo that = (RequestMappingInfo)object;
+		return httpMethod == that.httpMethod && Objects.equal(url, that.url);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(httpMethod, url);
+	}
+
+}

--- a/src/main/resources/assets/error/400.html
+++ b/src/main/resources/assets/error/400.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>400 Bad Request</title>
+    <title>4xx client errors</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -35,8 +35,8 @@
 </head>
 <body>
 <div class="container">
-    <h1>400 Bad Request</h1>
-    <p>Sorry, the server could not understand your request.</p>
+    <h1>4xx client errors</h1>
+    <p>check status code</p>
     <p>Please check your request and try again.</p>
 </div>
 </body>

--- a/src/main/resources/assets/error/500.html
+++ b/src/main/resources/assets/error/500.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>5xx client errors</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            text-align: center;
+            background-color: #f0f0f0;
+        }
+
+        .container {
+            padding: 20px;
+            border-radius: 8px;
+            background: #fff;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+
+        h1 {
+            color: #e53935;
+        }
+
+        p {
+            color: #555;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>5xx server errors</h1>
+    <p>Sorry, the server could not understand your request.</p>
+    <p>Please check your request and try again.</p>
+</div>
+</body>
+</html>

--- a/src/test/java/project/server/spring/framework/http/FileExtensionTest.java
+++ b/src/test/java/project/server/spring/framework/http/FileExtensionTest.java
@@ -1,9 +1,11 @@
 package project.server.spring.framework.http;
 
-import static org.assertj.core.api.Java6Assertions.*;
+// import static org.assertj.core.api.Java6Assertions.*;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static project.server.spring.framework.http.FileExtension.*;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -25,9 +27,6 @@ class FileExtensionTest {
 	@ParameterizedTest
 	@NullAndEmptySource
 	void testNull(String parameter) {
-		assertThatThrownBy(() -> findByType(parameter))
-			.isInstanceOf(RuntimeException.class)
-			.isExactlyInstanceOf(IllegalArgumentException.class)
-			.hasMessage("no file extension");
+		Assertions.assertThrows(IllegalArgumentException.class, () -> findByType(parameter));
 	}
 }


### PR DESCRIPTION
## 📝 구현 내용
- [X] 인터셉터 처리 추가
- [X] 캐싱 작업 추가

<br>
<br>
<br>

## ✨ 인터셉터
인증이 필요한 요청의 인증로직을 인터셉터로 옮겨, 공통적으로 처리하도록 만들었습니다. 그리고 WebMvcConfigurer 구현체를 통해 인터셉터를 추가할 수 있게끔 했습니다.
```java
@Slf4j
public class AuthenticationInterceptor extends HandlerInterceptor {
	private static final String USER_ID = "user_id";

	@Override
	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws
		Exception {
		log.info("authentication is required : request {}", request.getRequestURI());
		HttpSession session = request.getSession();
		if (session == null || session.getAttribute(USER_ID) == null) {
			throw new AuthenticationException(AUTHENTICATION_FAILED.getMessage());
		}
		return true;
	}
}
```
<br>
<br>
<br>

```java
@Configuration
public class AuthConfig implements WebMvcConfigurer {
	private final AuthenticationInterceptor authenticationInterceptor;

	public AuthConfig(AuthenticationInterceptor authenticationInterceptor) {
		this.authenticationInterceptor = authenticationInterceptor;
	}

	@Override
	public void addInterceptors(InterceptorRegistry registry) {
		registry.addInterceptor(authenticationInterceptor)
			.addUris("/profile")
			.order(1);
	}
}
```
애플리케이션이 시작될 때, WebMvcConfigurerComposite에서 WebMvcConfigurer 구현체들의 메소드를 실행시켜 InterceptorRegistry에 인터셉터들을 추가합니다. 그리고 DispatcherServlet에서 핸들러 어댑터 실행 전 `applyPreHandle()` 메소드를 통해서 요청의 핸들러의 인터셉터들을 실행시킵니다. 

<br>
<br>
<br>


```java
public class DispatcherServlet extends FrameworkServlet {

	private void doDispatch(HttpServletRequest request, HttpServletResponse response) throws Exception {
	      ...
	      HandlerExecutionChain handler = getHandler(request);
	      if (handler == null) {
		      throw new NoHandlerFoundException();
	      }
	      HandlerAdapter handlerAdapter = getHandlerAdapter(handler.getHandler());
	      if (!handler.applyPreHandle(request, response)) {
		      return;
	      }
	      ModelAndView modelAndView = handlerAdapter.handle(request, response, handler.getHandler());
	      ...

	}

```

<br>
<br>
<br>

## 🔨  에러페이지 및 핸들러 매핑 정보 캐싱 작업 추가
에러페이지는 매번 I/O 작업을 통해 읽어오던 것을, 애플리케이션 시작할 때, 메모리에 로드하여 비정상적인 요청 발생 시 빠르게 읽어오도록 구현했습니다. 또한 핸들러 매핑 정보도 애플리케이션 시작 시, HashMap 자료구조를 통해 저장해두어 요청의 URI와 Http 메소드에 맞는 핸들러를 바로 찾아올 수 있게 했습니다.

<br>

```java
	private HandlerExecutionChain getHandler(HttpServletRequest request) throws Exception {
		for (HandlerMapping mapping : this.handlerMappings) {
			HandlerExecutionChain handler = mapping.getHandler(request);
			if (handler != null) {
				return handler;
			}
		}
		return null;
	}
```